### PR TITLE
feat: use config/locale/*.js as default I18N folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## 功能
 
-- 支持多种语言独立配置，统一存放在 config/locales/*.js 下；
+- 支持多种语言独立配置，统一存放在 config/locale/*.js 下（ 兼容`config/locales/*.js` ）；
 - 提供 Middleware 为 View 提供 `__`, `gettext` 函数获取多语言文案；
 - 基于 URL 参数 `locale` 修改语言显示，同时会记录到 Cookie，下次请求会用 Cookie 里面的语言方案。
 
@@ -61,7 +61,7 @@ exports.i18n = {
 ## 编写你的 I18n 多语言文件
 
 ```js
-// config/locales/zh-CN.js
+// config/locale/zh-CN.js
 module.exports = {
   "Email": "邮箱",
   "Welcome back, %s!": "欢迎回来，%s!",
@@ -70,7 +70,7 @@ module.exports = {
 ```
 
 ```js
-// config/locales/en-US.js
+// config/locale/en-US.js
 module.exports = {
   "Email": "Email",
 };
@@ -79,7 +79,7 @@ module.exports = {
 或者也可以用 JSON 格式的文件：
 
 ```json
-// config/locales/zh-CN.json
+// config/locale/zh-CN.json
 {
   "email": "邮箱",
   "login": "帐号",
@@ -89,7 +89,7 @@ module.exports = {
 
 ## 使用 I18n 函数获取语言文本
 
-I18n 为你提供 `__` (Alias: `gettext`) 函数，让你可以轻松获得 locales 文件夹下面的多语言文本。
+I18n 为你提供 `__` (Alias: `gettext`) 函数，让你可以轻松获得 locale 文件夹下面的多语言文本。
 
 > NOTE: __ 是两个下划线哦！
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
 
 ## 功能
 
-- 支持多种语言独立配置，统一存放在 config/locales/*.js 下；
+- 支持多种语言独立配置，统一存放在 config/locale/*.js 下（ 兼容`config/locales/*.js` ）；
 - 提供 Middleware 为 View 提供 `__`, `gettext` 函数获取多语言文案；
 - 基于 URL 参数 `locale` 修改语言显示，同时会记录到 Cookie，下次请求会用 Cookie 里面的语言方案。
 
@@ -61,7 +61,7 @@ exports.i18n = {
 ## 编写你的 I18n 多语言文件
 
 ```js
-// config/locales/zh-CN.js
+// config/locale/zh-CN.js
 module.exports = {
   "Email": "邮箱",
   "Welcome back, %s!": "欢迎回来，%s!",
@@ -70,7 +70,7 @@ module.exports = {
 ```
 
 ```js
-// config/locales/en-US.js
+// config/locale/en-US.js
 module.exports = {
   "Email": "Email",
 };
@@ -79,7 +79,7 @@ module.exports = {
 或者也可以用 JSON 格式的文件：
 
 ```json
-// config/locales/zh-CN.json
+// config/locale/zh-CN.json
 {
   "email": "邮箱",
   "login": "帐号",
@@ -89,7 +89,7 @@ module.exports = {
 
 ## 使用 I18n 函数获取语言文本
 
-I18n 为你提供 `__` (Alias: `gettext`) 函数，让你可以轻松获得 locales 文件夹下面的多语言文本。
+I18n 为你提供 `__` (Alias: `gettext`) 函数，让你可以轻松获得 locale 文件夹下面的多语言文本。
 
 > NOTE: __ 是两个下划线哦！
 

--- a/test/fixtures/apps/loader/c/config/locale/zh-CN.js
+++ b/test/fixtures/apps/loader/c/config/locale/zh-CN.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  pluginC: 'i18n form locale',
+};

--- a/test/fixtures/apps/loader/c/config/locales/zh-CN.js
+++ b/test/fixtures/apps/loader/c/config/locales/zh-CN.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  pluginC: 'i18n form locales',
+};

--- a/test/fixtures/apps/loader/c/package.json
+++ b/test/fixtures/apps/loader/c/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "c",
+  "eggPlugin": {
+    "name": "c"
+  }
+}

--- a/test/fixtures/apps/loader/config/plugin.js
+++ b/test/fixtures/apps/loader/config/plugin.js
@@ -11,4 +11,8 @@ module.exports = {
     enable: true,
     path: path.join(__dirname, '../b'),
   },
+  c: {
+    enable: true,
+    path: path.join(__dirname, '../c'),
+  },
 };

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -123,6 +123,13 @@ describe('test/i18n.test.js', () => {
         .expect('true', done);
     });
 
+    it('should use locale/ when both exist locales/ and locale/', function(done) {
+      request(app.callback())
+        .get('/?key=pluginC')
+        .set('Accept-Language', 'zh-CN,zh;q=0.5')
+        .expect('i18n form locale', done);
+    });
+
     describe('view renderString with __(key, value)', () => {
       it('should render with default locale: en-US', function(done) {
         request(app.callback())


### PR DESCRIPTION
use `config/locale/*.js` as default I18N folder (`config/locales/*.js` is compatible)